### PR TITLE
Backports for 0.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.6'
+          - '1.7'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
+          - '1.7-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
     tags: '*'
 jobs:
   test:

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -375,6 +375,9 @@ function enzyme!(job, mod, primalf, adjoint, split, parallel)
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
         "jl_alloc_array_3d" => @cfunction(alloc_rule,
                                             UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
+                                                    Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef)),
+        "julia.pointer_from_objref" => @cfunction(inout_rule,
+                                            UInt8, (Cint, API.CTypeTreeRef, Ptr{API.CTypeTreeRef},
                                                     Ptr{API.IntList}, Csize_t, LLVM.API.LLVMValueRef))
     )
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -583,6 +583,10 @@ function GPUCompiler.codegen(output::Symbol, job::CompilerJob{<:EnzymeTarget};
 
         sparam_vals = mi.specTypes.parameters[2:end] # mi.sparam_vals
 
+        if func == Base.println
+            llvmfn = functions(mod)[k.specfunc]
+            push!(function_attributes(llvmfn), StringAttribute("enzyme_inactive"; ctx))
+        end
         if func == Base.copy && length(sparam_vals) == 1 && first(sparam_vals) <: Array
             AT = first(sparam_vals)
             T = eltype(AT)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,16 @@ end
 
 end
 
+@testset "IO" begin
+
+    function printsq(x)
+        println(x)
+        x*x
+    end
+
+    autodiff(printsq, Active(2.3))
+end
+
 @testset "hmlstm" begin
     sigm(x)  = @fastmath 1 / (1 + exp(-x))
     @fastmath function hmlstm_update_c_scalar(z, zb, c, f, i, g)


### PR DESCRIPTION
- Test on 1.6, 1.7, and 1.8
- Update CI.yml
- Type rule for pointer_from_objref (#83)
- Mark print as inactive (#85)
- add release to CI
