### PR TITLE
Fix GPU support

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1475,7 +1475,7 @@ function GPUCompiler.codegen(output::Symbol, job::CompilerJob{<:EnzymeTarget};
         linkage!(fn, LLVM.API.LLVMLinkerPrivateLinkage)
     end
 
-    return mod, (;adjointf, augmented_primalf)
+    return mod, (;adjointf, augmented_primalf, entry=adjointf, compiled=meta.compiled)
 end
 
 ##


### PR DESCRIPTION
Billy, for adding GPU tests we can use the JuliaGPU infrastructure, but we need to move it to an organisation
(buildkite restriction).
