### PR TITLE
Fix the readme's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Enzyme.jl can be used by calling `autodiff` on a function to be differentiated a
 using Enzyme, Test
 
 f1(x) = x*x
-@test autodiff(f1, Active(1.0)) == (2.0,)
+# Returns a tuple of active returns, which in this case is simply (2.0,)
+@test first(autodiff(f1, Active(1.0))) ≈ 2.0
 ```
 
 For details, see the [package documentation](https://enzyme.mit.edu/julia).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Enzyme.jl can be used by calling `autodiff` on a function to be differentiated a
 using Enzyme, Test
 
 f1(x) = x*x
-@test autodiff(f1, Active(1.0)) ≈ 2.0
+@test autodiff(f1, Active(1.0)) == (2.0,)
 ```
 
 For details, see the [package documentation](https://enzyme.mit.edu/julia).


### PR DESCRIPTION
As written it tries to compare a tuple to a number:
```
julia> @test autodiff(f1, Active(1.0)) ≈ 2.0
Error During Test at REPL[236]:1
  Test threw exception
  Expression: autodiff(f1, Active(1.0)) ≈ 2.0
  MethodError: no method matching isapprox(::Tuple{Float64}, ::Float64)
```