### PR TITLE
Use overlay table for AD functions

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -278,4 +278,7 @@ Adapt.adapt_structure(to, x::DuplicatedNoNeed) = DuplicatedNoNeed(adapt(to, x.va
 Adapt.adapt_structure(to, x::Const) = Const(adapt(to, x.val))
 Adapt.adapt_structure(to, x::Active) = Active(adapt(to, x.val))
 
+import .Compiler: @enzyme_override
+@enzyme_override Base.log(x::Float64) = ccall("llvm.log.f64", llvmcall, Float64, (Float64,), x)
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,8 @@ end
     @test autodiff(tanh, Active, Active(1.0f0))[1] ≈ Float32(0.41997434161402606939)
     test_scalar(f1, 1.0)
     test_scalar(f2, 1.0)
+
+    @test autodiff(x->log(x), Active(2.0)) == (0.5,)
 end
 
 @testset "Duplicated" begin


### PR DESCRIPTION
Alternative to #164

Might be problematic for CUDA.jl since we lose the method overlays for CUDA codes.
Still need to verify that.
