### PR TITLE
Allow markType to work in primal

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -375,6 +375,15 @@ Like [`fwddiff_deferred`](@ref) but will try to guess the activity of the return
     fwddiff_deferred(f, rt, args′...)
 end
 
+# White lie, should be `Core.LLVMPtr{Cvoid, 0}` but that's not supported by ccallable
+Base.@ccallable function __enzyme_float(x::Ptr{Cvoid})::Cvoid
+    return nothing
+end
+
+Base.@ccallable function __enzyme_double(x::Ptr{Cvoid})::Cvoid
+    return nothing
+end
+
 @inline function markType(::Type{Float32}, ptr)
     Base.llvmcall(("declare void @__enzyme_float(i8* nocapture) nounwind define void @c(i64 %q) nounwind alwaysinline { %p = inttoptr i64 %q to i8* call void @__enzyme_float(i8* %p) ret void }", "c"), Cvoid, Tuple{Ptr{Cvoid}}, ptr)
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -731,8 +731,8 @@ end
 end
 
 @testset "Exception" begin
-    f(x) = x'*x
+    f_exc(x) = x'*x
     y = [1.0, 2.0]
     f_x = zero.(y)
-    @test_throws Enzyme.CompilationException autodiff(f, Duplicated(y, f_x))
+    @test_throws Enzyme.CompilationException autodiff(f_exc, Duplicated(y, f_x))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -719,6 +719,10 @@ end
     dx = [5.0]
     dy = [7.0]
 
+    GC.@preserve x y begin
+        foo(Base.unsafe_convert(Ptr{Cvoid}, x), Base.unsafe_convert(Ptr{Cvoid}, y))
+    end
+
     GC.@preserve x y dx dy begin
       autodiff(foo,
                 Duplicated(Base.unsafe_convert(Ptr{Cvoid}, x), Base.unsafe_convert(Ptr{Cvoid}, dx)), 


### PR DESCRIPTION
- Allow `markType` to work in primal
- rename function in test
